### PR TITLE
paketti clipboard features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/AI_COLLABORATION_GUIDE.md
+++ b/AI_COLLABORATION_GUIDE.md
@@ -21,39 +21,45 @@ You are an expert music production assistant specializing in Renoise pattern dat
 
 ## **Understanding the Data Format**
 
-The data comes in this specific text format:
+The data comes in this specific text format (CopyPaste-V2):
 
 ```
 === RENOISE PATTERN DATA ===
-Format: Simple-V1
+Format: CopyPaste-V2
+BPM: 140 | LPB: 4 | Pattern: 01 | Lines: 64
 Selection: L001-016 T001-004
 
-Line | T01:Kick Drum | T02:Snare | T03:Hi-Hat | T04:Bass
+Line | T01:Kick Drum (N:1 F:2) | T02:Snare (N:1 F:1) | T03:Hi-Hat (N:1 F:1) | T04:Bass (N:2 F:1)
 
-001 | C-2 01 80 40 00 0A00 | --- .. .. .. .. .... | G#4 03 60 -- -- ---- | C-3 05 7F 40 00 ----
-002 | --- .. .. .. .. ---- | C-3 02 7F 40 00 ---- | --- .. .. .. .. ---- | --- .. .. .. .. ----
-003 | C-2 01 78 40 00 ---- | --- .. .. .. .. ---- | G#4 03 58 -- -- 1A20 | F-3 05 75 40 00 ----
-004 | --- .. .. .. .. 0C40 | --- .. .. .. .. ---- | --- .. .. .. .. ---- | --- .. .. .. .. ----
+001 | C-2 01 80 40 00 .... 0A00 0B00 | --- .. .. .. .. .... .... | G#4 03 60 40 00 .... .... | C-3 05 7F 40 00 .... ....
+002 | --- .. .. .. .. .... .... .... | C-3 02 7F 40 00 .... .... | --- .. .. .. .. .... .... | --- .. .. .. .. .... ....
+003 | C-2 01 78 40 05 .... .... .... | --- .. .. .. .. .... .... | G#4 03 58 40 00 1A20 .... | F-3 05 75 40 00 .... ....
+004 | --- .. .. .. .. .... 0C40 .... | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | --- .. .. .. .. .... ....
 
 === END PATTERN DATA ===
 ```
 
 ## **Format Reference**
 
-**Structure:**
-- `Line`: Pattern line number (001-999)
-- `T01:Name`: Track number and name
-- Each track contains: `Note Instrument Volume Effect1 Effect2 ...`
+**Header Information:**
+- `BPM`: Song tempo in beats per minute
+- `LPB`: Lines per beat
+- `Pattern`: Current pattern number
+- `Lines`: Total lines in pattern
 
-**Note Format:**
-- `C-4`, `D#5`, etc. = Musical notes (C, C#, D, D#, E, F, F#, G, G#, A, A#, B) + octave (0-9)
-- `---` = Empty note slot  
-- `OFF` = Note off command
+**Track Header:**
+- `T01:Name (N:1 F:2)`: Track number, name, note columns (N), effect columns (F)
 
-**Values (all in hexadecimal):**
-- **Instrument**: `01`-`FF` (instruments 1-255), `..` = empty
-- **Volume**: `00`-`7F` (0-127), `..` = empty  
-- **Effects**: `0A00` = effect number + amount, `....` = empty
+**Note Column (6 parts per column):**
+- `C-4` = Note (C-0 to B-9), `---` = empty, `OFF` = note off
+- `01` = Instrument (00-FF hex), `..` = empty
+- `80` = Volume (00-7F hex), `..` = empty
+- `40` = Panning (00-7F hex, 40=center), `..` = empty
+- `00` = Delay (00-FF hex), `..` = empty
+- `....` = Sample Effect (XXYY hex), `....` = empty
+
+**Effect Column:**
+- `0A00` = Effect command (XXYY hex), `....` = empty
   - Effect numbers: `00`-`23` (0-35 decimal)
   - Effect amounts: `00`-`FF` (0-255 decimal)
 
@@ -100,24 +106,25 @@ When I share pattern data or request changes:
 
 **Me:** "Transpose this pattern up 5 semitones and add some hi-hat variations"
 
-**You:** "I'll transpose all notes up 5 semitones (perfect 4th) and add rhythmic variations to the hi-hat track with different velocities and some 16th note patterns.
+**You:** "I'll transpose all notes up 5 semitones (perfect 4th) and add rhythmic variations to the hi-hat track with different velocities and some delay values for swing.
 
 ```
 === RENOISE PATTERN DATA ===
-Format: Simple-V1  
+Format: CopyPaste-V2
+BPM: 140 | LPB: 4 | Pattern: 01 | Lines: 64
 Selection: L001-004 T001-003
 
-Line | T01:Kick | T02:Snare | T03:Hi-Hat Enhanced
+Line | T01:Kick (N:1 F:1) | T02:Snare (N:1 F:1) | T03:Hi-Hat Enhanced (N:1 F:1)
 
-001 | F-2 01 80 | --- .. .. | C-5 03 60 
-002 | --- .. .. | F-3 02 7F | C-5 03 45
-003 | F-2 01 78 | --- .. .. | C-5 03 70
-004 | --- .. .. | --- .. .. | C-5 03 55
+001 | F-2 01 80 40 00 .... .... | --- .. .. .. .. .... .... | C-5 03 60 40 00 .... ....
+002 | --- .. .. .. .. .... .... | F-3 02 7F 40 00 .... .... | C-5 03 45 40 10 .... ....
+003 | F-2 01 78 40 00 .... .... | --- .. .. .. .. .... .... | C-5 03 70 40 00 .... ....
+004 | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | C-5 03 55 40 08 .... ....
 
 === END PATTERN DATA ===
 ```
 
-The kick and snare transposed from C-2/C-3 to F-2/F-3, and I added consistent hi-hat with velocity variations (60, 45, 70, 55) for a more humanized feel."
+The kick and snare transposed from C-2/C-3 to F-2/F-3, and I added consistent hi-hat with velocity variations (60, 45, 70, 55) and subtle delay values (10, 08) for a more humanized, swinging feel."
 
 ## **Ready to Work!**
 
@@ -139,19 +146,20 @@ What pattern would you like to work with?
 "Analyze this drum pattern and suggest improvements for the groove:"
 
 === RENOISE PATTERN DATA ===
-Format: Simple-V1
+Format: CopyPaste-V2
+BPM: 120 | LPB: 4 | Pattern: 01 | Lines: 64
 Selection: L001-008 T001-003
 
-Line | T01:Kick | T02:Snare | T03:Hi-Hat
+Line | T01:Kick (N:1 F:1) | T02:Snare (N:1 F:1) | T03:Hi-Hat (N:1 F:1)
 
-001 | C-2 01 80 | --- .. .. | G#4 03 40
-002 | --- .. .. | --- .. .. | G#4 03 30
-003 | --- .. .. | C-3 02 7F | G#4 03 40
-004 | --- .. .. | --- .. .. | G#4 03 30
-005 | C-2 01 78 | --- .. .. | G#4 03 40
-006 | --- .. .. | --- .. .. | G#4 03 30
-007 | --- .. .. | C-3 02 75 | G#4 03 40
-008 | --- .. .. | --- .. .. | G#4 03 35
+001 | C-2 01 80 40 00 .... .... | --- .. .. .. .. .... .... | G#4 03 40 40 00 .... ....
+002 | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | G#4 03 30 40 00 .... ....
+003 | --- .. .. .. .. .... .... | C-3 02 7F 40 00 .... .... | G#4 03 40 40 00 .... ....
+004 | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | G#4 03 30 40 00 .... ....
+005 | C-2 01 78 40 00 .... .... | --- .. .. .. .. .... .... | G#4 03 40 40 00 .... ....
+006 | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | G#4 03 30 40 00 .... ....
+007 | --- .. .. .. .. .... .... | C-3 02 75 40 00 .... .... | G#4 03 40 40 00 .... ....
+008 | --- .. .. .. .. .... .... | --- .. .. .. .. .... .... | G#4 03 35 40 00 .... ....
 
 === END PATTERN DATA ===
 ```

--- a/README.md
+++ b/README.md
@@ -1,167 +1,239 @@
-# Simple Copy Paste Tool for Renoise - Usage Guide
+# Copy Paste Tool for Renoise - AI Collaboration Edition
 
 ## Overview
 
-This is a copy-paste tool for Renoise that allows you to copy pattern selections as text and paste them back, with additional save/load functionality for .regpat files.
-The final goal is to support full format specified in FORMAT_SPECIFICATION.md (under review, matter of change).
+An enhanced copy-paste tool for Renoise that allows you to copy pattern selections as human-readable text, share them with AI assistants (ChatGPT, Claude, etc.), and paste modified patterns back. Includes save/load functionality for `.regpat` files, plus a fast file-based Paketti Clipboard system.
+
+**Version:** 0.5  
+**API Version:** 6+  
+**Author:** Psychedel (enhanced with Paketti patterns)
+
+## Features
+
+### Core Functions
+- **Copy Selection to Text**: Convert pattern data to shareable text format
+- **Paste Text Data**: Apply text pattern data back to Renoise
+- **Mix-Paste**: Only paste into empty cells (Impulse Tracker Alt-M style)
+- **Quick Copy (No Dialog)**: Fast copy without opening dialog
+- **Save/Load Pattern Files**: Export and import patterns as `.regpat` files
+- **AI Collaboration Workflow**: Designed for sharing with AI assistants
+
+### Paketti Clipboard (NEW)
+- **Paketti Copy**: Copies selection to a persistent clipboard file (no dialog)
+- **Paketti Cut**: Copies to clipboard and clears the selection
+- **Paketti Paste**: Pastes from clipboard to current selection
+- **Paketti Mix-Paste**: Pastes from clipboard into empty cells only
+- **Persistent**: Works across Renoise sessions (file-based storage)
+
+### Pattern Data Support
+- **Full Note Columns**: Note, Instrument, Volume, Panning, Delay, Sample Effects
+- **Multiple Note Columns**: All visible note columns per track
+- **Effect Columns**: All visible effect columns per track
+- **Multiple Tracks**: Copy across any number of tracks
+- **Song Context**: BPM, LPB, pattern number included in header
+
+### Technical Features
+- **Undo Integration**: All paste operations create undo points
+- **MIDI Mappings**: Control via MIDI controllers
+- **Keyboard Shortcuts**: Assignable keybindings
+- **Dialog Management**: Proper Escape key handling
+- **Error Handling**: Graceful error recovery with logging
 
 ## Installation
 
-1. Copy the entire `com.psychedel.CopyPaste.xrnx` folder to your Renoise Tools directory:
+1. Copy the entire folder to your Renoise Tools directory:
    - **Windows**: `%APPDATA%\Renoise\V3.x.x\Scripts\Tools\`
    - **macOS**: `~/Library/Preferences/Renoise/V3.x.x/Scripts/Tools/`
    - **Linux**: `~/.renoise/V3.x.x/Scripts/Tools/`
 
 2. Restart Renoise or use "Tools > Reload All Tools"
 
-## Features
+## .regpat File Format (V2)
 
-### Core Functions
-- **Dialog-based Copy/Paste**: Text handling for manual editing and sharing
-- **Save/Load Pattern Files**: Export and import patterns as .regpat files
-- **Multi-Column Support**: Handles multiple note and effect columns per track
-- **Undo Integration**: All paste operations integrate with Renoise's undo system
-- **Simple Format**: Easy to read and edit text representation
-
-### What Gets Copied
-- Note data (note, instrument, volume) - all visible note columns
-- Effect commands - all visible effect columns
-- Track names and selection info
-- Pattern line numbers
-- Full multi-column pattern structure
-
-### File I/O Functions
-- **Save Pattern**: Export copied pattern data to .regpat files
-- **Load Pattern**: Import pattern data from .regpat or .txt files
-- **File Format**: Standard text format compatible with external editing
-
-## .regpat File Format
-
-The tool uses a simple text format for pattern files:
+The tool uses an enhanced text format:
 
 ```
 === RENOISE PATTERN DATA ===
-Format: Simple-V1
-Selection: L001-016 T001-005
+Format: CopyPaste-V2
+BPM: 140 | LPB: 4 | Pattern: 01 | Lines: 64
+Selection: L001-016 T001-003
 
-Line | T01:Track Name | T02:Track Name | T03:Track Name
-001 | C-4 01 7F 40 00 ---- | --- .. .. .. .. ---- | F#4 03 60 -- -- ----
-002 | --- .. .. .. .. ---- | D-3 02 7F 40 00 ---- | --- .. .. .. .. ----
+Line | T01:Kick Drum (N:1 F:2) | T02:Snare (N:1 F:1) | T03:Bass (N:2 F:1)
+
+001 | C-4 01 80 40 00 .... 0B40 | --- .. .. .. .. .... .... | C-3 05 7F .. .. .... ....
+002 | --- .. .. .. .. .... .... | D-4 02 7F 40 00 .... .... | --- .. .. .. .. .... ....
 ...
 === END PATTERN DATA ===
 ```
 
 ### Format Elements
-- **Note**: Musical note (C-4, D#5, etc.) or `---` for empty
-- **Instrument**: Hex value (01-FF) or `..` for empty
-- **Volume**: Hex value (00-7F) or `..` for empty
-- **Effects**: Hex effect commands (0A20, 1200, etc.) or `----` for empty
+
+**Note Column (6 parts):**
+- `C-4` - Note (C-0 to B-9, `---` empty, `OFF` note-off)
+- `01` - Instrument (00-FF hex, `..` empty)
+- `80` - Volume (00-7F hex, `..` empty)
+- `40` - Panning (00-7F hex, `..` empty)
+- `00` - Delay (00-FF hex, `..` empty)
+- `....` - Sample Effect (XXYY hex, `....` empty)
+
+**Effect Column:**
+- `0B40` - Effect command (XXYY hex, `....` empty)
 
 ## How to Use
 
-### Basic Copy/Paste Workflow
+### Basic Workflow
 
-1. **Select Pattern Area**
-   - In the Pattern Editor, select the area you want to copy
-   - Use Ctrl+A to select entire pattern, or mouse selection for specific areas
-   - Can be single or multiple tracks with multiple columns
+1. **Select Pattern Area** in Pattern Editor
+   - Use Ctrl+A for entire pattern, or mouse selection
 
-2. **Copy with Dialog**
-   - Use menu: `Pattern Editor > Copy Selection as Text`
-   - Or click "Copy Selection" button in the tool dialog
-   - View/edit text in dialog and manually copy to clipboard
+2. **Copy Selection**
+   - Menu: `Pattern Editor > Copy Paste > Copy Selection to Text...`
+   - Or use assigned keyboard shortcut
 
-3. **Paste with Dialog**
+3. **Share with AI**
+   - Copy the text from the dialog
+   - Paste into ChatGPT, Claude, or other AI assistant
+   - Ask for modifications (transpose, add variations, etc.)
+
+4. **Paste AI's Response**
    - Select destination area in Pattern Editor
-   - Use menu: `Pattern Editor > Paste Text Data`
-   - Or click "Paste Data" button in the tool dialog
-   - Paste and edit text before applying to pattern
-   - Automatically creates undo point
+   - Menu: `Pattern Editor > Copy Paste > Paste Text Data...`
+   - Paste the AI's modified pattern and click Apply
 
-### Save/Load Pattern Files
+### Quick Copy Workflow
 
-#### Saving Patterns
-1. **Copy a Selection** first (steps 1-2 above)
-2. **Click "Save Pattern"** in the tool dialog
-3. **Choose filename** - .regpat extension will be added automatically
-4. **Select location** - patterns folder recommended for organization
-5. **File is saved** and ready for sharing or later use
+For faster operation without dialogs:
+- Use "Quick Copy (No Dialog)" to copy silently
+- Data is stored in memory for pasting
 
-#### Loading Patterns
-1. **Click "Load Pattern"** in the tool dialog or menu
-2. **Select .regpat file** from the file browser
-3. **Review confirmation dialog** showing pattern dimensions and target area
-4. **Click "Load Pattern"** to apply directly to your song
-5. **Pattern automatically applied** using the original file dimensions (no selection required)
+### Mix-Paste Workflow (Impulse Tracker Alt-M Style)
 
+Mix-Paste only fills empty cells, preserving existing data:
 
+1. **Copy your pattern data** (melody, effects, etc.)
+2. **Move to destination** with existing content
+3. **Use Mix-Paste** instead of regular paste
+4. **Result**: New data fills gaps without overwriting existing notes
 
-### Text Format Example
+This is perfect for:
+- Layering patterns together
+- Adding effects to existing melodies
+- Merging multiple pattern clips non-destructively
 
-```
-=== RENOISE PATTERN DATA ===
-Format: Simple-V1
-Selection: L001-004 T001-002
+### File Workflow
 
-Line | T01:Track 01 | T02:Track 02
+**Save Pattern:**
+1. Copy a selection first
+2. Click "Save to File" or use menu
+3. Choose location and filename (`.regpat` extension)
 
-001 | C-5 01 40 0A00 | --- .. .. ....
-002 | --- .. .. .... | D-5 02 30 0B10
-003 | E-5 01 50 .... | --- .. .. ....
-004 | OFF .. .. .... | F-5 03 60 0C20
+**Load Pattern:**
+1. Click "Load from File" or use menu
+2. Select `.regpat` or `.txt` file
+3. Review confirmation dialog
+4. Pattern applies using original file dimensions
 
-=== END PATTERN DATA ===
-```
+### Paketti Clipboard Workflow
 
-### Format Explanation
+The Paketti Clipboard provides fast, no-dialog Cut/Copy/Paste using a persistent file:
 
-- **Line numbers**: `001`, `002`, etc.
-- **Note format**: `C-5` (note + octave), `---` (empty), `OFF` (note off)
-- **Instrument**: `01` (hex), `..` (empty)
-- **Volume**: `40` (hex), `..` (empty)
-- **Effect**: `0A00` (effect + value), `....` (empty)
+**Paketti Copy:**
+1. Select pattern area in Pattern Editor
+2. Run "Paketti Copy" (via menu, keybinding, or MIDI)
+3. Data is saved to `paketti_clipboard.txt` in the tool folder
+
+**Paketti Cut:**
+1. Select pattern area in Pattern Editor
+2. Run "Paketti Cut"
+3. Data is copied to clipboard file, then selection is cleared
+
+**Paketti Paste:**
+1. Select destination area in Pattern Editor
+2. Run "Paketti Paste"
+3. Clipboard data is pasted, overwriting existing content
+
+**Paketti Mix-Paste:**
+1. Select destination area with existing content
+2. Run "Paketti Mix-Paste"
+3. Clipboard data only fills empty cells, preserving existing notes
+
+**Benefits:**
+- **No dialogs**: Fast workflow for rapid editing
+- **Persistent**: Clipboard survives Renoise restarts
+- **Undo support**: All operations create undo points
+- **Keybinding friendly**: Assign shortcuts for tracker-style workflow
 
 ## Menu Locations
 
 ### Main Menu
-- `Main Menu > Tools > Copy Paste...` - Opens main dialog with all options
+- `Main Menu > Tools > Copy Paste...` - Opens main dialog
 
-### Pattern Editor
-- `Pattern Editor > Copy Selection as Text` - Copy with dialog
-- `Pattern Editor > Paste Text Data` - Paste with dialog
+### Pattern Editor Context Menu
+- `Pattern Editor > Copy Paste > Copy Selection to Text...`
+- `Pattern Editor > Copy Paste > Quick Copy (No Dialog)`
+- `Pattern Editor > Copy Paste > Paste Text Data...`
+- `Pattern Editor > Copy Paste > Mix-Paste (Empty Cells Only)`
+- `Pattern Editor > Copy Paste > Save Pattern to File...`
+- `Pattern Editor > Copy Paste > Load Pattern from File...`
+- `Pattern Editor > Copy Paste > Paketti Copy`
+- `Pattern Editor > Copy Paste > Paketti Cut`
+- `Pattern Editor > Copy Paste > Paketti Paste`
+- `Pattern Editor > Copy Paste > Paketti Mix-Paste`
 
 ## Keyboard Shortcuts
 
-You can assign keyboard shortcuts through:
-1. `Edit > Preferences > Keys`
-2. Look for:
-   - `Pattern Editor > Tools > Copy Selection as Text`
-   - `Pattern Editor > Tools > Paste Text Data`
+Assign through `Edit > Preferences > Keys`:
+
+- `Pattern Editor:Copy Paste:Show Main Dialog`
+- `Pattern Editor:Copy Paste:Copy Selection to Text`
+- `Pattern Editor:Copy Paste:Quick Copy (No Dialog)`
+- `Pattern Editor:Copy Paste:Paste Text Data`
+- `Pattern Editor:Copy Paste:Mix-Paste (Empty Cells Only)`
+- `Pattern Editor:Copy Paste:Save Pattern to File`
+- `Pattern Editor:Copy Paste:Load Pattern from File`
+- `Pattern Editor:Copy Paste:Paketti Copy`
+- `Pattern Editor:Copy Paste:Paketti Cut`
+- `Pattern Editor:Copy Paste:Paketti Paste`
+- `Pattern Editor:Copy Paste:Paketti Mix-Paste`
 
 **Recommended shortcuts:**
 - Copy Selection: `Ctrl+Shift+C`
+- Quick Copy: `Ctrl+Alt+C`
 - Paste Data: `Ctrl+Shift+V`
+- Mix-Paste: `Alt+M` (Impulse Tracker style)
+- Paketti Copy: `Ctrl+Alt+Shift+C`
+- Paketti Cut: `Ctrl+Alt+Shift+X`
+- Paketti Paste: `Ctrl+Alt+Shift+V`
 
-## Tips and Best Practices
+## MIDI Mappings
 
-### For Music Production
-- **Multi-column support**: Copy complex patterns with multiple note/effect columns
-- **Undo safety**: All paste operations can be undone with Ctrl+Z
-- Copy drum patterns to share with collaborators
-- Share musical ideas via text (Discord, forums, etc.)
+Available in `MIDI Mappings`:
 
-### For AI Collaboration
-- The text format is perfect for sharing with AI assistants
-- You can describe changes in plain text and paste results back
-- AI can help analyze and modify patterns
-- Easy to version control with Git
+- `Copy Paste:Copy Selection to Text`
+- `Copy Paste:Quick Copy (No Dialog)`
+- `Copy Paste:Paste Text Data`
+- `Copy Paste:Mix-Paste (Empty Cells Only)`
+- `Copy Paste:Show Main Dialog`
+- `Copy Paste:Paketti Copy`
+- `Copy Paste:Paketti Cut`
+- `Copy Paste:Paketti Paste`
+- `Copy Paste:Paketti Mix-Paste`
 
-### Editing Text Manually
-- Use any text editor to modify the pattern data
-- **Dialog editing**: Use "Paste Text Data" for in-app text editing
-- Maintain the exact format structure
-- Be careful with spacing and separators (`|`)
-- Multi-column data is properly aligned and parsed
+## AI Collaboration Tips
+
+### Effective Prompts
+
+```
+"Transpose this pattern up 5 semitones"
+"Add swing to the hi-hat (vary the delay values)"
+"Create a variation with different velocities"
+"Double the pattern length with variations"
+"Add a bass line that follows this chord progression"
+```
+
+### AI Prompt Template
+
+See `AI_COLLABORATION_GUIDE.md` for a complete prompt template to share with AI assistants.
 
 ## Troubleshooting
 
@@ -169,31 +241,62 @@ You can assign keyboard shortcuts through:
 
 **"No selection to copy"**
 - Make sure you have selected an area in the Pattern Editor
-- Even a single cell counts as a selection
 
 **"No data to paste"**
-- Copy some pattern data first
-- Check that clipboard contains valid pattern data
+- Copy some pattern data first, or paste text into the dialog
 
 **"No valid pattern data found"**
-- Ensure the text format is correct
-- Check for proper headers and line numbers
-- Verify the `=== RENOISE PATTERN DATA ===` header exists
+- Ensure the text has proper format headers
+- Check for `=== RENOISE PATTERN DATA ===` header
 
 **Pasted data looks wrong**
-- Check that destination selection is appropriate size
-- Verify track count matches source data
-- Ensure you're pasting to the correct pattern/location
+- Verify track column counts match between source and destination
+- Check that you're pasting to the correct pattern
 
 ### Debug Information
-- Check Renoise's console for error messages
-- The tool outputs status messages during operation
-- File path: `[Tool Directory]/debug.log` (if available)
 
-## Current Limitations
+- Check Renoise's console (View > Show Scripting Console) for log messages
+- Messages prefixed with `[Copy Paste]`
 
-- Only copies basic pattern data (notes, instruments, volume, effects)
-- Does not copy track settings, device chains, or automation
-- Copies all visible note/effect columns (no longer limited to first column)
-- No advanced formatting options
-- Does not preserve column visibility settings on paste
+## Changelog
+
+### v0.5 (Current)
+- **Paketti Clipboard**: New file-based Cut/Copy/Paste system
+  - `Paketti Copy`: Copies selection to persistent clipboard file
+  - `Paketti Cut`: Copies to clipboard and clears selection
+  - `Paketti Paste`: Pastes from clipboard to current selection
+  - `Paketti Mix-Paste`: Pastes into empty cells only
+- Clipboard persists across Renoise sessions (stored in `paketti_clipboard.txt`)
+- Updated main dialog with Paketti Clipboard buttons
+- Added menu entries, keybindings, and MIDI mappings for all Paketti functions
+
+### v0.4
+- **Mix-Paste mode**: Only paste into empty cells (Impulse Tracker Alt-M style)
+- Paste dialog now has two buttons: "Paste (Overwrite)" and "Mix-Paste (Empty Only)"
+- Dedicated menu entry, keybinding, and MIDI mapping for Mix-Paste
+- Status messages indicate when mix-paste mode was used
+
+### v0.3
+- Enhanced format with full note column support (Pan, Delay, Sample FX)
+- Song context in header (BPM, LPB, Pattern, Lines)
+- Track column counts in header (N:x F:y)
+- MIDI mappings support
+- Quick Copy mode (no dialog)
+- Proper Escape key handling in all dialogs
+- Keyboard focus restoration after dialogs
+- Improved error handling and logging
+- Monospace font in text dialogs
+- Dialog state management (proper cleanup)
+
+### v0.2
+- Multi-column support (note and effect columns)
+- File I/O (.regpat format)
+- Undo integration
+
+### v0.1
+- Initial release
+- Basic copy/paste functionality
+
+## License
+
+See LICENSE file.

--- a/main.lua
+++ b/main.lua
@@ -1,25 +1,58 @@
 -- Copy-Paste Tool for Renoise
+-- Enhanced with patterns from Paketti
 
 local APP_NAME = "Copy Paste"
-local APP_VERSION = "0.2"
+local APP_VERSION = "0.5"
 
+--------------------------------------------------------------------------------
 -- Global state for storing copied data
+--------------------------------------------------------------------------------
 local copied_data = nil
 local last_selection = nil
 local copy_dialog = nil
 local paste_dialog = nil
 local load_confirm_dialog = nil
+local main_dialog = nil
+local save_dialog = nil
 
-function keyhandler_func(dialog, key)
+--------------------------------------------------------------------------------
+-- Paketti Clipboard file path (persistent temp file)
+--------------------------------------------------------------------------------
+local PAKETTI_CLIPBOARD_FILE = renoise.tool().bundle_path .. "paketti_clipboard.txt"
+
+--------------------------------------------------------------------------------
+-- Keyhandler function (Paketti pattern)
+-- Handles Escape key to close dialogs properly
+--------------------------------------------------------------------------------
+local function create_keyhandler(dialog_getter, dialog_setter)
+    return function(dialog, key)
+        -- Close on Escape key
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            if dialog_setter then
+                dialog_setter(nil)
+            end
+            return nil
+        end
+        return key
+    end
+end
+
+-- Default keyhandler for dialogs without specific setters
+local function default_keyhandler(dialog, key)
+    if key.modifiers == "" and key.name == "esc" then
+        dialog:close()
+        return nil
+    end
     return key
 end
 
+--------------------------------------------------------------------------------
 -- Utility functions
+--------------------------------------------------------------------------------
 local function log(message)
     print("[" .. APP_NAME .. "] " .. tostring(message))
 end
-
-
 
 local function get_current_selection()
     local song = renoise.song()
@@ -40,6 +73,9 @@ local function get_current_selection()
     }
 end
 
+--------------------------------------------------------------------------------
+-- Formatting functions
+--------------------------------------------------------------------------------
 local function format_note(note_value)
     if note_value == 121 then
         return "OFF"
@@ -71,6 +107,31 @@ local function format_volume(vol_value)
     end
 end
 
+local function format_panning(pan_value)
+    if pan_value == renoise.PatternLine.EMPTY_PANNING then
+        return ".."
+    else
+        return string.format("%02X", pan_value)
+    end
+end
+
+local function format_delay(delay_value)
+    if delay_value == renoise.PatternLine.EMPTY_DELAY then
+        return ".."
+    else
+        return string.format("%02X", delay_value)
+    end
+end
+
+local function format_sample_effect(effect_number, effect_amount)
+    if effect_number == renoise.PatternLine.EMPTY_EFFECT_NUMBER then
+        return "...."
+    else
+        local amount = effect_amount == renoise.PatternLine.EMPTY_EFFECT_AMOUNT and 0 or effect_amount
+        return string.format("%02X%02X", effect_number, amount)
+    end
+end
+
 local function format_effect(effect_number, effect_amount)
     if effect_number == renoise.PatternLine.EMPTY_EFFECT_NUMBER then
         return "...."
@@ -80,92 +141,9 @@ local function format_effect(effect_number, effect_amount)
     end
 end
 
-local function copy_selection_to_text(show_dialog)
-    local selection = get_current_selection()
-    if not selection then
-        renoise.app():show_status("No selection to copy")
-        return
-    end
-
-    last_selection = selection
-
-    local song = renoise.song()
-    local pattern = song.selected_pattern
-    local output = {}
-
-    -- Header
-    table.insert(output, "=== RENOISE PATTERN DATA ===")
-    table.insert(output, "Format: Safe-V1")
-    table.insert(output, string.format("Selection: L%03d-%03d T%03d-%03d",
-        selection.start_line, selection.end_line,
-        selection.start_track, selection.end_track))
-    table.insert(output, "")
-
-    -- Track names
-    local track_header = "Line"
-    for track_idx = selection.start_track, selection.end_track do
-        local track = song.tracks[track_idx]
-        track_header = track_header .. string.format(" | T%02d:%s", track_idx, track.name)
-    end
-    table.insert(output, track_header)
-    table.insert(output, "")
-
-    -- Pattern data
-    for line_idx = selection.start_line, selection.end_line do
-        local line_str = string.format("%03d", line_idx)
-
-        for track_idx = selection.start_track, selection.end_track do
-            local track = pattern:track(track_idx)
-            local line = track:line(line_idx)
-
-            line_str = line_str .. " |"
-
-            -- Note columns
-            local visible_note_cols = song.tracks[track_idx].visible_note_columns
-            for col_idx = 1, math.max(1, visible_note_cols) do
-                if col_idx <= #line.note_columns then
-                    local note_col = line.note_columns[col_idx]
-                    local note = format_note(note_col.note_value)
-                    local instr = format_instrument(note_col.instrument_value)
-                    local vol = format_volume(note_col.volume_value)
-                    line_str = line_str .. string.format(" %s %s %s", note, instr, vol)
-                else
-                    line_str = line_str .. " --- .. .."
-                end
-            end
-
-            -- Effect columns
-            local visible_fx_cols = song.tracks[track_idx].visible_effect_columns
-            for col_idx = 1, math.max(1, visible_fx_cols) do
-                if col_idx <= #line.effect_columns then
-                    local fx_col = line.effect_columns[col_idx]
-                    local effect = format_effect(fx_col.number_value, fx_col.amount_value)
-                    line_str = line_str .. " " .. effect
-                else
-                    line_str = line_str .. " ...."
-                end
-            end
-        end
-
-        table.insert(output, line_str)
-    end
-
-    table.insert(output, "")
-    table.insert(output, "=== END PATTERN DATA ===")
-
-    copied_data = table.concat(output, "\n")
-
-    log("Selection copied (" .. (selection.end_line - selection.start_line + 1) .. " lines, " ..
-        (selection.end_track - selection.start_track + 1) .. " tracks)")
-
-    renoise.app():show_status("Pattern data copied")
-
-    -- Show copy dialog only if requested
-    if show_dialog ~= false then
-        show_copy_dialog(copied_data)
-    end
-end
-
+--------------------------------------------------------------------------------
+-- Parsing functions
+--------------------------------------------------------------------------------
 local function parse_note(note_str)
     if note_str == "---" then
         return 120 -- Empty note
@@ -173,18 +151,9 @@ local function parse_note(note_str)
         return 121 -- Note off
     else
         local note_names = {
-            ["C-"] = 0,
-            ["C#"] = 1,
-            ["D-"] = 2,
-            ["D#"] = 3,
-            ["E-"] = 4,
-            ["F-"] = 5,
-            ["F#"] = 6,
-            ["G-"] = 7,
-            ["G#"] = 8,
-            ["A-"] = 9,
-            ["A#"] = 10,
-            ["B-"] = 11
+            ["C-"] = 0, ["C#"] = 1, ["D-"] = 2, ["D#"] = 3,
+            ["E-"] = 4, ["F-"] = 5, ["F#"] = 6, ["G-"] = 7,
+            ["G#"] = 8, ["A-"] = 9, ["A#"] = 10, ["B-"] = 11
         }
         local note_name = note_str:sub(1, 2)
         local octave = tonumber(note_str:sub(3, 3))
@@ -195,11 +164,55 @@ local function parse_note(note_str)
     return 120 -- Default to empty
 end
 
-local function parse_hex_value(hex_str, empty_value)
+local function parse_instrument_value(hex_str)
     if hex_str == ".." then
-        return empty_value
+        return renoise.PatternLine.EMPTY_INSTRUMENT
     else
-        return tonumber(hex_str, 16) or empty_value
+        local value = tonumber(hex_str, 16)
+        if value and value >= 0 and value <= 255 then
+            return value
+        else
+            return renoise.PatternLine.EMPTY_INSTRUMENT
+        end
+    end
+end
+
+local function parse_volume_value(hex_str)
+    if hex_str == ".." then
+        return renoise.PatternLine.EMPTY_VOLUME
+    else
+        local value = tonumber(hex_str, 16)
+        if value and value >= 0 and value <= 127 then
+            return value
+        else
+            return renoise.PatternLine.EMPTY_VOLUME
+        end
+    end
+end
+
+local function parse_panning_value(hex_str)
+    if hex_str == ".." then
+        return renoise.PatternLine.EMPTY_PANNING
+    else
+        local value = tonumber(hex_str, 16)
+        if value and value >= 0 and value <= 127 then
+            return value
+        else
+            return renoise.PatternLine.EMPTY_PANNING
+        end
+    end
+end
+
+local function parse_delay_value(hex_str)
+    if hex_str == ".." then
+        return renoise.PatternLine.EMPTY_DELAY
+    else
+        local value = tonumber(hex_str, 16)
+        if value and value >= 0 and value <= 255 then
+            return value
+        else
+            return renoise.PatternLine.EMPTY_DELAY
+        end
     end
 end
 
@@ -229,32 +242,6 @@ local function parse_effect_amount(hex_str)
     end
 end
 
-local function parse_instrument_value(hex_str)
-    if hex_str == ".." then
-        return renoise.PatternLine.EMPTY_INSTRUMENT
-    else
-        local value = tonumber(hex_str, 16)
-        if value and value >= 0 and value <= 255 then
-            return value
-        else
-            return renoise.PatternLine.EMPTY_INSTRUMENT
-        end
-    end
-end
-
-local function parse_volume_value(hex_str)
-    if hex_str == ".." then
-        return renoise.PatternLine.EMPTY_VOLUME
-    else
-        local value = tonumber(hex_str, 16)
-        if value and value >= 0 and value <= 127 then
-            return value
-        else
-            return renoise.PatternLine.EMPTY_VOLUME
-        end
-    end
-end
-
 -- Parse selection info from pattern data header
 local function parse_selection_info(text_data)
     local lines = {}
@@ -276,11 +263,118 @@ local function parse_selection_info(text_data)
     return nil
 end
 
-local function apply_text_data(text_data, use_file_dimensions)
+--------------------------------------------------------------------------------
+-- Copy Selection to Text
+--------------------------------------------------------------------------------
+local function copy_selection_to_text(show_dialog)
+    local selection = get_current_selection()
+    if not selection then
+        renoise.app():show_status("No selection to copy")
+        return nil
+    end
+
+    last_selection = selection
+
+    local song = renoise.song()
+    local pattern = song.selected_pattern
+    local transport = song.transport
+    local output = {}
+
+    -- Header with more context (Paketti-style: include useful song info)
+    table.insert(output, "=== RENOISE PATTERN DATA ===")
+    table.insert(output, "Format: CopyPaste-V2")
+    table.insert(output, string.format("BPM: %d | LPB: %d | Pattern: %02d | Lines: %d",
+        transport.bpm, transport.lpb, song.selected_pattern_index, pattern.number_of_lines))
+    table.insert(output, string.format("Selection: L%03d-%03d T%03d-%03d",
+        selection.start_line, selection.end_line,
+        selection.start_track, selection.end_track))
+    table.insert(output, "")
+
+    -- Track names with column info
+    local track_header = "Line"
+    for track_idx = selection.start_track, selection.end_track do
+        local track = song.tracks[track_idx]
+        local note_cols = track.visible_note_columns
+        local fx_cols = track.visible_effect_columns
+        track_header = track_header .. string.format(" | T%02d:%s (N:%d F:%d)", 
+            track_idx, track.name, note_cols, fx_cols)
+    end
+    table.insert(output, track_header)
+    table.insert(output, "")
+
+    -- Pattern data
+    for line_idx = selection.start_line, selection.end_line do
+        local line_str = string.format("%03d", line_idx)
+
+        for track_idx = selection.start_track, selection.end_track do
+            local track = pattern:track(track_idx)
+            local line = track:line(line_idx)
+            local song_track = song.tracks[track_idx]
+
+            line_str = line_str .. " |"
+
+            -- Note columns (with all sub-columns)
+            local visible_note_cols = song_track.visible_note_columns
+            for col_idx = 1, math.max(1, visible_note_cols) do
+                if col_idx <= #line.note_columns then
+                    local note_col = line.note_columns[col_idx]
+                    local note = format_note(note_col.note_value)
+                    local instr = format_instrument(note_col.instrument_value)
+                    local vol = format_volume(note_col.volume_value)
+                    local pan = format_panning(note_col.panning_value)
+                    local dly = format_delay(note_col.delay_value)
+                    local sfx = format_sample_effect(note_col.effect_number_value, note_col.effect_amount_value)
+                    line_str = line_str .. string.format(" %s %s %s %s %s %s", note, instr, vol, pan, dly, sfx)
+                else
+                    line_str = line_str .. " --- .. .. .. .. ...."
+                end
+            end
+
+            -- Effect columns
+            local visible_fx_cols = song_track.visible_effect_columns
+            for col_idx = 1, math.max(1, visible_fx_cols) do
+                if col_idx <= #line.effect_columns then
+                    local fx_col = line.effect_columns[col_idx]
+                    local effect = format_effect(fx_col.number_value, fx_col.amount_value)
+                    line_str = line_str .. " " .. effect
+                else
+                    line_str = line_str .. " ...."
+                end
+            end
+        end
+
+        table.insert(output, line_str)
+    end
+
+    table.insert(output, "")
+    table.insert(output, "=== END PATTERN DATA ===")
+
+    copied_data = table.concat(output, "\n")
+
+    local lines_count = selection.end_line - selection.start_line + 1
+    local tracks_count = selection.end_track - selection.start_track + 1
+    log("Selection copied (" .. lines_count .. " lines, " .. tracks_count .. " tracks)")
+    renoise.app():show_status(string.format("Pattern data copied: %d lines, %d tracks", lines_count, tracks_count))
+
+    -- Show copy dialog only if requested
+    if show_dialog ~= false then
+        show_copy_dialog(copied_data)
+    end
+    
+    return copied_data
+end
+
+--------------------------------------------------------------------------------
+-- Apply Text Data (Paste)
+-- mix_paste_mode: if true, only paste into empty cells (Impulse Tracker style)
+--------------------------------------------------------------------------------
+local function apply_text_data(text_data, use_file_dimensions, mix_paste_mode)
     if not text_data or text_data == "" then
         renoise.app():show_status("No data to paste")
         return false
     end
+    
+    mix_paste_mode = mix_paste_mode or false
 
     local selection
     if use_file_dimensions then
@@ -290,8 +384,6 @@ local function apply_text_data(text_data, use_file_dimensions)
             renoise.app():show_status("Could not parse selection info from file")
             return false
         end
-
-        -- When loading from file, we ignore current selection and use file dimensions
         log("Loading pattern with file dimensions: L" .. selection.start_line .. "-" .. selection.end_line ..
             " T" .. selection.start_track .. "-" .. selection.end_track)
     else
@@ -326,7 +418,7 @@ local function apply_text_data(text_data, use_file_dimensions)
 
     local song = renoise.song()
 
-    -- Add undo point
+    -- Add undo point (Paketti pattern)
     song:describe_undo("Paste Pattern Data")
 
     local pattern = song.selected_pattern
@@ -339,6 +431,7 @@ local function apply_text_data(text_data, use_file_dimensions)
     -- Paste data
     for i = data_start, data_end do
         if paste_line > selection.end_line then break end
+        if paste_line > pattern.number_of_lines then break end
 
         local line_data = lines[i]
         local line_num = tonumber(line_data:sub(1, 3))
@@ -349,6 +442,7 @@ local function apply_text_data(text_data, use_file_dimensions)
             -- Parse track data
             for track_data in line_data:gmatch("|([^|]*)") do
                 if track_idx > selection.end_track then break end
+                if track_idx > #song.tracks then break end
 
                 local success, error_msg = pcall(function()
                     local track = pattern:track(track_idx)
@@ -362,20 +456,41 @@ local function apply_text_data(text_data, use_file_dimensions)
                     end
 
                     -- Apply multi-column note data
+                    -- New format: Note Instr Vol Pan Delay SampleFX (6 parts per note column)
                     local visible_note_cols = song_track.visible_note_columns
                     local note_col_idx = 1
                     local part_idx = 1
 
-                    -- Process note columns (groups of 3: note, instrument, volume)
-                    while note_col_idx <= visible_note_cols and part_idx + 2 <= #parts do
+                    -- Process note columns (groups of 6: note, instrument, volume, panning, delay, sample_fx)
+                    while note_col_idx <= visible_note_cols and part_idx + 5 <= #parts do
                         if note_col_idx <= #line.note_columns then
                             local note_col = line.note_columns[note_col_idx]
-                            note_col.note_value = parse_note(parts[part_idx])
-                            note_col.instrument_value = parse_instrument_value(parts[part_idx + 1])
-                            note_col.volume_value = parse_volume_value(parts[part_idx + 2])
+                            
+                            -- Mix-paste mode: only paste into empty cells (Impulse Tracker Alt-M style)
+                            local should_paste = true
+                            if mix_paste_mode and not note_col.is_empty then
+                                should_paste = false
+                            end
+                            
+                            if should_paste then
+                                note_col.note_value = parse_note(parts[part_idx])
+                                note_col.instrument_value = parse_instrument_value(parts[part_idx + 1])
+                                note_col.volume_value = parse_volume_value(parts[part_idx + 2])
+                                note_col.panning_value = parse_panning_value(parts[part_idx + 3])
+                                note_col.delay_value = parse_delay_value(parts[part_idx + 4])
+                                -- Sample effect (parts[part_idx + 5])
+                                local sfx_str = parts[part_idx + 5]
+                                if sfx_str and sfx_str ~= "...." and #sfx_str >= 4 then
+                                    note_col.effect_number_value = parse_effect_number(sfx_str:sub(1, 2))
+                                    note_col.effect_amount_value = parse_effect_amount(sfx_str:sub(3, 4))
+                                else
+                                    note_col.effect_number_value = renoise.PatternLine.EMPTY_EFFECT_NUMBER
+                                    note_col.effect_amount_value = renoise.PatternLine.EMPTY_EFFECT_AMOUNT
+                                end
+                            end
                         end
                         note_col_idx = note_col_idx + 1
-                        part_idx = part_idx + 3
+                        part_idx = part_idx + 6
                     end
 
                     -- Apply multi-column effect data
@@ -386,13 +501,22 @@ local function apply_text_data(text_data, use_file_dimensions)
                     while fx_col_idx <= visible_fx_cols and part_idx <= #parts do
                         if fx_col_idx <= #line.effect_columns then
                             local fx_col = line.effect_columns[fx_col_idx]
-                            local effect_str = parts[part_idx]
-                            if effect_str and effect_str ~= "...." and effect_str:len() >= 4 then
-                                fx_col.number_value = parse_effect_number(effect_str:sub(1, 2))
-                                fx_col.amount_value = parse_effect_amount(effect_str:sub(3, 4))
-                            else
-                                fx_col.number_value = renoise.PatternLine.EMPTY_EFFECT_NUMBER
-                                fx_col.amount_value = renoise.PatternLine.EMPTY_EFFECT_AMOUNT
+                            
+                            -- Mix-paste mode: only paste into empty cells
+                            local should_paste_fx = true
+                            if mix_paste_mode and not fx_col.is_empty then
+                                should_paste_fx = false
+                            end
+                            
+                            if should_paste_fx then
+                                local effect_str = parts[part_idx]
+                                if effect_str and effect_str ~= "...." and #effect_str >= 4 then
+                                    fx_col.number_value = parse_effect_number(effect_str:sub(1, 2))
+                                    fx_col.amount_value = parse_effect_amount(effect_str:sub(3, 4))
+                                else
+                                    fx_col.number_value = renoise.PatternLine.EMPTY_EFFECT_NUMBER
+                                    fx_col.amount_value = renoise.PatternLine.EMPTY_EFFECT_AMOUNT
+                                end
                             end
                         end
                         fx_col_idx = fx_col_idx + 1
@@ -402,8 +526,7 @@ local function apply_text_data(text_data, use_file_dimensions)
 
                 if not success then
                     errors_encountered = errors_encountered + 1
-                    log("Error processing track " ..
-                        track_idx .. " at line " .. paste_line .. ": " .. tostring(error_msg))
+                    log("Error processing track " .. track_idx .. " at line " .. paste_line .. ": " .. tostring(error_msg))
                 end
 
                 track_idx = track_idx + 1
@@ -414,21 +537,214 @@ local function apply_text_data(text_data, use_file_dimensions)
         paste_line = paste_line + 1
     end
 
+    local mode_str = mix_paste_mode and " (mix-paste: empty cells only)" or ""
     if errors_encountered > 0 then
-        log("Pattern data pasted with " .. errors_encountered .. " errors (" .. lines_processed .. " lines processed)")
-        renoise.app():show_status("Pattern data pasted with " .. errors_encountered .. " errors")
+        log("Pattern data pasted with " .. errors_encountered .. " errors (" .. lines_processed .. " lines processed)" .. mode_str)
+        renoise.app():show_status("Pattern data pasted with " .. errors_encountered .. " errors" .. mode_str)
     else
-        log("Pattern data pasted successfully (" .. lines_processed .. " lines processed)")
-        renoise.app():show_status("Pattern data pasted successfully")
+        log("Pattern data pasted successfully (" .. lines_processed .. " lines processed)" .. mode_str)
+        renoise.app():show_status("Pattern data pasted successfully (" .. lines_processed .. " lines)" .. mode_str)
     end
     return true
 end
 
+--------------------------------------------------------------------------------
+-- Mix-Paste from clipboard buffer (Impulse Tracker Alt-M style)
+-- Only pastes into empty cells
+--------------------------------------------------------------------------------
+local function mix_paste_from_buffer()
+    if not copied_data then
+        renoise.app():show_status("No pattern data in buffer. Copy a selection first.")
+        return
+    end
+    
+    local success = apply_text_data(copied_data, false, true)
+    if not success then
+        renoise.app():show_status("Mix-paste failed")
+    end
+end
 
+--------------------------------------------------------------------------------
+-- Paketti Clipboard Functions (File-based Cut/Copy/Paste)
+--------------------------------------------------------------------------------
 
+-- Write pattern data to the Paketti clipboard file
+local function write_to_paketti_clipboard(pattern_data)
+    local file, err = io.open(PAKETTI_CLIPBOARD_FILE, "w")
+    if not file then
+        log("Failed to write to Paketti clipboard: " .. tostring(err))
+        return false
+    end
+    file:write(pattern_data)
+    file:close()
+    log("Pattern data written to Paketti clipboard file")
+    return true
+end
+
+-- Read pattern data from the Paketti clipboard file
+local function read_from_paketti_clipboard()
+    local file, err = io.open(PAKETTI_CLIPBOARD_FILE, "r")
+    if not file then
+        log("Failed to read from Paketti clipboard: " .. tostring(err))
+        return nil
+    end
+    local content = file:read("*all")
+    file:close()
+    if content and content ~= "" then
+        log("Pattern data read from Paketti clipboard file")
+        return content
+    end
+    return nil
+end
+
+-- Clear the current selection in the pattern
+local function clear_current_selection()
+    local selection = get_current_selection()
+    if not selection then
+        log("No selection to clear")
+        return false
+    end
+    
+    local song = renoise.song()
+    local pattern = song.selected_pattern
+    
+    song:describe_undo("Paketti Cut - Clear Selection")
+    
+    for line_idx = selection.start_line, selection.end_line do
+        for track_idx = selection.start_track, selection.end_track do
+            if track_idx <= #song.tracks then
+                local track = pattern:track(track_idx)
+                local line = track:line(line_idx)
+                local song_track = song.tracks[track_idx]
+                
+                -- Clear note columns
+                local visible_note_cols = song_track.visible_note_columns
+                for col_idx = 1, visible_note_cols do
+                    if col_idx <= #line.note_columns then
+                        local note_col = line.note_columns[col_idx]
+                        note_col.note_value = 120 -- Empty
+                        note_col.instrument_value = renoise.PatternLine.EMPTY_INSTRUMENT
+                        note_col.volume_value = renoise.PatternLine.EMPTY_VOLUME
+                        note_col.panning_value = renoise.PatternLine.EMPTY_PANNING
+                        note_col.delay_value = renoise.PatternLine.EMPTY_DELAY
+                        note_col.effect_number_value = renoise.PatternLine.EMPTY_EFFECT_NUMBER
+                        note_col.effect_amount_value = renoise.PatternLine.EMPTY_EFFECT_AMOUNT
+                    end
+                end
+                
+                -- Clear effect columns
+                local visible_fx_cols = song_track.visible_effect_columns
+                for col_idx = 1, visible_fx_cols do
+                    if col_idx <= #line.effect_columns then
+                        local fx_col = line.effect_columns[col_idx]
+                        fx_col.number_value = renoise.PatternLine.EMPTY_EFFECT_NUMBER
+                        fx_col.amount_value = renoise.PatternLine.EMPTY_EFFECT_AMOUNT
+                    end
+                end
+            end
+        end
+    end
+    
+    local lines_count = selection.end_line - selection.start_line + 1
+    local tracks_count = selection.end_track - selection.start_track + 1
+    log("Selection cleared: " .. lines_count .. " lines, " .. tracks_count .. " tracks")
+    return true
+end
+
+-- Paketti Copy: Copy selection to clipboard file (no dialog)
+local function paketti_copy()
+    local data = copy_selection_to_text(false)
+    if data then
+        if write_to_paketti_clipboard(data) then
+            local selection = get_current_selection()
+            if selection then
+                local lines_count = selection.end_line - selection.start_line + 1
+                local tracks_count = selection.end_track - selection.start_track + 1
+                renoise.app():show_status(string.format("Paketti Copy: %d lines, %d tracks copied to clipboard", lines_count, tracks_count))
+            else
+                renoise.app():show_status("Paketti Copy: Pattern data copied to clipboard")
+            end
+        else
+            renoise.app():show_status("Paketti Copy: Failed to write to clipboard file")
+        end
+    else
+        renoise.app():show_status("Paketti Copy: No selection to copy")
+    end
+end
+
+-- Paketti Cut: Copy selection to clipboard file, then clear selection
+local function paketti_cut()
+    local data = copy_selection_to_text(false)
+    if data then
+        if write_to_paketti_clipboard(data) then
+            local selection = get_current_selection()
+            local lines_count = 0
+            local tracks_count = 0
+            if selection then
+                lines_count = selection.end_line - selection.start_line + 1
+                tracks_count = selection.end_track - selection.start_track + 1
+            end
+            
+            -- Now clear the selection
+            if clear_current_selection() then
+                renoise.app():show_status(string.format("Paketti Cut: %d lines, %d tracks cut to clipboard", lines_count, tracks_count))
+            else
+                renoise.app():show_status("Paketti Cut: Copied but failed to clear selection")
+            end
+        else
+            renoise.app():show_status("Paketti Cut: Failed to write to clipboard file")
+        end
+    else
+        renoise.app():show_status("Paketti Cut: No selection to cut")
+    end
+end
+
+-- Paketti Paste: Read from clipboard file and paste at current position
+local function paketti_paste()
+    local clipboard_data = read_from_paketti_clipboard()
+    if not clipboard_data then
+        renoise.app():show_status("Paketti Paste: Clipboard is empty. Use Paketti Copy first.")
+        return
+    end
+    
+    -- Store in the internal buffer as well
+    copied_data = clipboard_data
+    
+    local success = apply_text_data(clipboard_data, false, false)
+    if success then
+        renoise.app():show_status("Paketti Paste: Pattern data pasted successfully")
+    else
+        renoise.app():show_status("Paketti Paste: Failed to paste pattern data")
+    end
+end
+
+-- Paketti Mix-Paste: Read from clipboard file and paste only into empty cells
+local function paketti_mix_paste()
+    local clipboard_data = read_from_paketti_clipboard()
+    if not clipboard_data then
+        renoise.app():show_status("Paketti Mix-Paste: Clipboard is empty. Use Paketti Copy first.")
+        return
+    end
+    
+    -- Store in the internal buffer as well
+    copied_data = clipboard_data
+    
+    local success = apply_text_data(clipboard_data, false, true)
+    if success then
+        renoise.app():show_status("Paketti Mix-Paste: Pattern data pasted into empty cells")
+    else
+        renoise.app():show_status("Paketti Mix-Paste: Failed to paste pattern data")
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Dialog Functions
+--------------------------------------------------------------------------------
 function show_copy_dialog(text_data)
+    -- Close existing dialog if open (Paketti pattern)
     if copy_dialog and copy_dialog.visible then
         copy_dialog:close()
+        copy_dialog = nil
     end
 
     local vb = renoise.ViewBuilder()
@@ -444,57 +760,92 @@ function show_copy_dialog(text_data)
         },
 
         vb:text {
-            text = "Copy this text to share your pattern data:"
+            text = "Copy this text to share with AI assistants (ChatGPT, Claude, etc.):"
         },
 
         vb:multiline_textfield {
             text = text_data,
-            width = 600,
-            height = 300,
-            edit_mode = false
+            width = 700,
+            height = 400,
+            edit_mode = false,
+            font = "mono"
         },
 
         vb:horizontal_aligner {
             mode = "center",
+            spacing = 10,
+            
+            vb:button {
+                text = "Copy Again",
+                width = 100,
+                notifier = function()
+                    copy_selection_to_text(false)
+                    if copy_dialog and copy_dialog.visible then
+                        copy_dialog:close()
+                        copy_dialog = nil
+                    end
+                    show_copy_dialog(copied_data)
+                end
+            },
+            
             vb:button {
                 text = "Close",
                 width = 100,
                 notifier = function()
-                    if copy_dialog then copy_dialog:close() end
+                    if copy_dialog then 
+                        copy_dialog:close() 
+                        copy_dialog = nil
+                    end
                 end
             }
         }
     }
 
-    copy_dialog = renoise.app():show_custom_dialog("Copy Pattern Data", dialog_content, keyhandler_func)
+    -- Create keyhandler that sets copy_dialog to nil on close
+    local keyhandler = function(dialog, key)
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            copy_dialog = nil
+            return nil
+        end
+        return key
+    end
+
+    copy_dialog = renoise.app():show_custom_dialog("Copy Pattern Data", dialog_content, keyhandler)
+    
+    -- Paketti pattern: Reset middle frame to ensure keyboard focus returns to Renoise
+    renoise.app().window.active_middle_frame = renoise.app().window.active_middle_frame
 end
 
 function show_paste_dialog()
+    -- Close existing dialog if open
     if paste_dialog and paste_dialog.visible then
         paste_dialog:close()
+        paste_dialog = nil
     end
 
     local vb = renoise.ViewBuilder()
 
     local text_field = vb:multiline_textfield {
         text = copied_data or "",
-        width = 600,
-        height = 300,
-        edit_mode = true
+        width = 700,
+        height = 400,
+        edit_mode = true,
+        font = "mono"
     }
 
     local dialog_content = vb:column {
         margin = 10,
-        --    spacing = 10,
-        --[[
+        spacing = 10,
+
         vb:text {
             text = "Paste Pattern Data",
             font = "big",
             style = "strong"
         },
-]] --
+
         vb:text {
-            text = "Paste pattern data text here and click Apply:"
+            text = "Paste pattern data text here (from AI assistant or file) and click Apply:"
         },
 
         text_field,
@@ -504,30 +855,64 @@ function show_paste_dialog()
             spacing = 10,
 
             vb:button {
-                text = "Apply",
-                width = 100,
+                text = "Paste (Overwrite)",
+                width = 120,
                 notifier = function()
-                    local success = apply_text_data(text_field.text, false)
+                    local success = apply_text_data(text_field.text, false, false)
                     if success and paste_dialog then
                         paste_dialog:close()
+                        paste_dialog = nil
+                    end
+                end
+            },
+
+            vb:button {
+                text = "Mix-Paste (Empty Only)",
+                width = 140,
+                notifier = function()
+                    local success = apply_text_data(text_field.text, false, true)
+                    if success and paste_dialog then
+                        paste_dialog:close()
+                        paste_dialog = nil
                     end
                 end
             },
 
             vb:button {
                 text = "Cancel",
-                width = 100,
+                width = 80,
                 notifier = function()
-                    if paste_dialog then paste_dialog:close() end
+                    if paste_dialog then 
+                        paste_dialog:close() 
+                        paste_dialog = nil
+                    end
                 end
             }
+        },
+        
+        vb:text {
+            text = "Mix-Paste: Only fills empty cells, preserves existing data (Impulse Tracker Alt-M style)"
         }
     }
 
-    paste_dialog = renoise.app():show_custom_dialog("Paste Pattern Data", dialog_content)
+    local keyhandler = function(dialog, key)
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            paste_dialog = nil
+            return nil
+        end
+        return key
+    end
+
+    paste_dialog = renoise.app():show_custom_dialog("Paste Pattern Data", dialog_content, keyhandler)
+    
+    -- Paketti pattern: Reset middle frame
+    renoise.app().window.active_middle_frame = renoise.app().window.active_middle_frame
 end
 
+--------------------------------------------------------------------------------
 -- File I/O functions
+--------------------------------------------------------------------------------
 local function save_pattern_to_file(filename, pattern_data)
     local file, err = io.open(filename, "w")
     if not file then
@@ -556,6 +941,12 @@ local function show_save_dialog()
     if not copied_data then
         renoise.app():show_status("No pattern data to save. Copy a selection first.")
         return
+    end
+
+    -- Close existing if open
+    if save_dialog and save_dialog.visible then
+        save_dialog:close()
+        save_dialog = nil
     end
 
     -- Parse current data to show info
@@ -614,6 +1005,10 @@ local function show_save_dialog()
                         if save_pattern_to_file(filename, copied_data) then
                             renoise.app():show_status("Pattern saved to: " .. filename)
                             log("Pattern data saved to file: " .. filename)
+                            if save_dialog then
+                                save_dialog:close()
+                                save_dialog = nil
+                            end
                         else
                             renoise.app():show_error("Failed to save pattern to: " .. filename)
                         end
@@ -625,16 +1020,35 @@ local function show_save_dialog()
                 text = "Cancel",
                 width = 100,
                 notifier = function()
-                    -- Just close dialog
+                    if save_dialog then
+                        save_dialog:close()
+                        save_dialog = nil
+                    end
                 end
             }
         }
     }
 
-    renoise.app():show_custom_dialog("Save Pattern", dialog_content)
+    local keyhandler = function(dialog, key)
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            save_dialog = nil
+            return nil
+        end
+        return key
+    end
+
+    save_dialog = renoise.app():show_custom_dialog("Save Pattern", dialog_content, keyhandler)
+    renoise.app().window.active_middle_frame = renoise.app().window.active_middle_frame
 end
 
 local function show_load_confirmation_dialog(pattern_data, filename)
+    -- Close existing if open
+    if load_confirm_dialog and load_confirm_dialog.visible then
+        load_confirm_dialog:close()
+        load_confirm_dialog = nil
+    end
+
     local file_selection = parse_selection_info(pattern_data)
     if not file_selection then
         renoise.app():show_error("Could not parse pattern dimensions from file")
@@ -645,6 +1059,9 @@ local function show_load_confirmation_dialog(pattern_data, filename)
 
     local lines_count = file_selection.end_line - file_selection.start_line + 1
     local tracks_count = file_selection.end_track - file_selection.start_track + 1
+
+    -- Extract just the filename for display
+    local display_filename = filename:match("([^/\\]+)$") or filename
 
     local dialog_content = vb:column {
         margin = 10,
@@ -657,7 +1074,7 @@ local function show_load_confirmation_dialog(pattern_data, filename)
         },
 
         vb:text {
-            text = "File: " .. filename
+            text = "File: " .. display_filename
         },
 
         vb:text {
@@ -673,7 +1090,8 @@ local function show_load_confirmation_dialog(pattern_data, filename)
         },
 
         vb:text {
-            text = "\nThis will overwrite the current pattern data in the specified range."
+            text = "\nThis will overwrite the current pattern data in the specified range.",
+            style = "strong"
         },
 
         vb:horizontal_aligner {
@@ -686,14 +1104,15 @@ local function show_load_confirmation_dialog(pattern_data, filename)
                 notifier = function()
                     local success = apply_text_data(pattern_data, true)
                     if success then
-                        renoise.app():show_status("Pattern loaded and applied from: " .. filename)
+                        renoise.app():show_status("Pattern loaded and applied from: " .. display_filename)
                         log("Pattern data loaded and applied from file: " .. filename)
                     else
-                        renoise.app():show_status("Failed to load pattern from: " .. filename)
+                        renoise.app():show_status("Failed to load pattern from: " .. display_filename)
                         log("Failed to apply pattern from file: " .. filename)
                     end
                     if load_confirm_dialog then
                         load_confirm_dialog:close()
+                        load_confirm_dialog = nil
                     end
                 end
             },
@@ -704,13 +1123,24 @@ local function show_load_confirmation_dialog(pattern_data, filename)
                 notifier = function()
                     if load_confirm_dialog then
                         load_confirm_dialog:close()
+                        load_confirm_dialog = nil
                     end
                 end
             }
         }
     }
 
-    load_confirm_dialog = renoise.app():show_custom_dialog("Load Pattern", dialog_content)
+    local keyhandler = function(dialog, key)
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            load_confirm_dialog = nil
+            return nil
+        end
+        return key
+    end
+
+    load_confirm_dialog = renoise.app():show_custom_dialog("Load Pattern", dialog_content, keyhandler)
+    renoise.app().window.active_middle_frame = renoise.app().window.active_middle_frame
 end
 
 local function show_load_dialog()
@@ -724,95 +1154,373 @@ local function show_load_dialog()
     end
 end
 
+--------------------------------------------------------------------------------
+-- Main Dialog
+--------------------------------------------------------------------------------
 local function show_main_dialog()
+    -- Close existing if open
+    if main_dialog and main_dialog.visible then
+        main_dialog:close()
+        main_dialog = nil
+    end
+
     local vb = renoise.ViewBuilder()
 
     local dialog_content = vb:column {
         margin = 10,
-        --spacing = 15,
-        --[[
+        spacing = 8,
+
         vb:text {
             text = APP_NAME .. " v" .. APP_VERSION,
             font = "big",
             style = "strong"
         },
-]] --
+
         vb:text {
-            text = "Enhanced pattern copy & paste tool with multi-column support and file I/O"
+            text = "Pattern copy & paste tool for AI collaboration"
         },
+
+        vb:space { height = 5 },
 
         vb:horizontal_aligner {
             mode = "center",
 
             vb:column {
-                --     spacing = 10,
+                spacing = 5,
+
+                vb:text {
+                    text = "AI Collaboration:",
+                    font = "bold"
+                },
 
                 vb:row {
+                    spacing = 5,
                     vb:button {
                         text = "Copy Selection",
-                        width = 95,
+                        width = 100,
                         height = 30,
-                        notifier = function() copy_selection_to_text(true) end
+                        notifier = function() 
+                            copy_selection_to_text(true) 
+                        end
                     },
 
                     vb:button {
                         text = "Paste Data",
-                        width = 95,
+                        width = 100,
                         height = 30,
                         notifier = show_paste_dialog
                     }
                 },
 
                 vb:row {
+                    spacing = 5,
                     vb:button {
-                        text = "Save Pattern",
-                        width = 95,
+                        text = "Save to File",
+                        width = 100,
                         height = 30,
                         notifier = show_save_dialog
                     },
 
                     vb:button {
-                        text = "Load Pattern",
-                        width = 95,
+                        text = "Load from File",
+                        width = 100,
                         height = 30,
                         notifier = show_load_dialog
+                    }
+                },
+
+                vb:space { height = 10 },
+
+                vb:text {
+                    text = "Paketti Clipboard:",
+                    font = "bold"
+                },
+
+                vb:row {
+                    spacing = 5,
+                    vb:button {
+                        text = "Paketti Copy",
+                        width = 100,
+                        height = 30,
+                        notifier = paketti_copy
+                    },
+
+                    vb:button {
+                        text = "Paketti Cut",
+                        width = 100,
+                        height = 30,
+                        notifier = paketti_cut
+                    }
+                },
+
+                vb:row {
+                    spacing = 5,
+                    vb:button {
+                        text = "Paketti Paste",
+                        width = 100,
+                        height = 30,
+                        notifier = paketti_paste
+                    },
+
+                    vb:button {
+                        text = "Paketti Mix-Paste",
+                        width = 100,
+                        height = 30,
+                        notifier = paketti_mix_paste
                     }
                 }
             }
         },
 
+        vb:space { height = 5 },
+
         vb:text {
-            text = "Instructions:\n" ..
-                "• Use Ctrl+A to select entire pattern in Renoise\n" ..
-                "• Copy: Shows dialog for text handling and sharing\n" ..
-                "• Save: Export current copied data to .regpat file\n" ..
-                "• Load: Import and auto-apply full pattern (no selection needed)\n" ..
-                "• Multi-column: Supports multiple note/effect columns\n" ..
-                "• Undo: Pattern edits integrate with Renoise undo"
+            text = "AI Collaboration:\n" ..
+                "1. Select pattern data in Pattern Editor\n" ..
+                "2. 'Copy Selection' generates shareable text\n" ..
+                "3. Share with AI (ChatGPT, Claude, etc.)\n" ..
+                "4. 'Paste Data' applies AI's modifications\n" ..
+                "\n" ..
+                "Paketti Clipboard:\n" ..
+                "• Copy/Cut/Paste using persistent file\n" ..
+                "• Works across Renoise sessions\n" ..
+                "• Mix-Paste: Only fills empty cells\n" ..
+                "\n" ..
+                "Features:\n" ..
+                "• Full note columns: Note, Instr, Vol, Pan, Delay, SampleFX\n" ..
+                "• Save/Load .regpat files for offline storage\n" ..
+                "• Undo integration (Ctrl+Z to revert)"
         }
     }
 
-    renoise.app():show_custom_dialog(APP_NAME .. " v" .. APP_VERSION, dialog_content, keyhandler_func)
-    renoise.app().window.active_middle_frame = renoise.ApplicationWindow.MIDDLE_FRAME_PATTERN_EDITOR
+    local keyhandler = function(dialog, key)
+        if key.modifiers == "" and key.name == "esc" then
+            dialog:close()
+            main_dialog = nil
+            return nil
+        end
+        return key
+    end
+
+    main_dialog = renoise.app():show_custom_dialog(APP_NAME, dialog_content, keyhandler)
+    
+    -- Paketti pattern: Reset middle frame to ensure keyboard focus
+    renoise.app().window.active_middle_frame = renoise.app().window.active_middle_frame
 end
 
+--------------------------------------------------------------------------------
+-- Quick copy without dialog (for fast workflow)
+--------------------------------------------------------------------------------
+local function quick_copy_selection()
+    local data = copy_selection_to_text(false)
+    if data then
+        renoise.app():show_status("Pattern data copied to clipboard buffer")
+    end
+end
+
+--------------------------------------------------------------------------------
 -- Menu entries
-renoise.tool():add_menu_entry { name = "Main Menu:Tools:" .. APP_NAME .. "...", invoke = show_main_dialog }
-renoise.tool():add_menu_entry { name = "Pattern Editor:Tools:Copy Selection to Text", invoke = function()
-    copy_selection_to_text(true)
-end }
-renoise.tool():add_menu_entry { name = "Pattern Editor:Tools:Paste Text Data", invoke = show_paste_dialog }
-renoise.tool():add_menu_entry { name = "Pattern Editor:Tools:Save Pattern to File", invoke = show_save_dialog }
-renoise.tool():add_menu_entry { name = "Pattern Editor:Tools:Load Pattern from File", invoke = show_load_dialog }
+--------------------------------------------------------------------------------
+renoise.tool():add_menu_entry { 
+    name = "Main Menu:Tools:" .. APP_NAME .. "...", 
+    invoke = show_main_dialog 
+}
 
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Copy Selection to Text...", 
+    invoke = function() copy_selection_to_text(true) end 
+}
 
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Quick Copy (No Dialog)", 
+    invoke = quick_copy_selection 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paste Text Data...", 
+    invoke = show_paste_dialog 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Save Pattern to File...", 
+    invoke = show_save_dialog 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Load Pattern from File...", 
+    invoke = show_load_dialog 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Mix-Paste (Empty Cells Only)", 
+    invoke = mix_paste_from_buffer 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "--Pattern Editor:" .. APP_NAME .. ":Paketti Copy", 
+    invoke = paketti_copy 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Cut", 
+    invoke = paketti_cut 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Paste", 
+    invoke = paketti_paste 
+}
+
+renoise.tool():add_menu_entry { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Mix-Paste", 
+    invoke = paketti_mix_paste 
+}
+
+--------------------------------------------------------------------------------
 -- Keybindings
-renoise.tool():add_keybinding { name = "Pattern Editor:Tools:Copy Selection to Text", invoke = function()
-    copy_selection_to_text(true)
-end }
-renoise.tool():add_keybinding { name = "Pattern Editor:Tools:Paste Text Data", invoke = show_paste_dialog }
-renoise.tool():add_keybinding { name = "Pattern Editor:Tools:Save Pattern to File", invoke = show_save_dialog }
-renoise.tool():add_keybinding { name = "Pattern Editor:Tools:Load Pattern from File", invoke = show_load_dialog }
+--------------------------------------------------------------------------------
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Show Main Dialog", 
+    invoke = show_main_dialog 
+}
 
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Copy Selection to Text", 
+    invoke = function() copy_selection_to_text(true) end 
+}
 
-log(APP_NAME .. " v" .. APP_VERSION .. " loaded successfully (with multi-column support & undo integration)")
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Quick Copy (No Dialog)", 
+    invoke = quick_copy_selection 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paste Text Data", 
+    invoke = show_paste_dialog 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Save Pattern to File", 
+    invoke = show_save_dialog 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Load Pattern from File", 
+    invoke = show_load_dialog 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Mix-Paste (Empty Cells Only)", 
+    invoke = mix_paste_from_buffer 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Copy", 
+    invoke = paketti_copy 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Cut", 
+    invoke = paketti_cut 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Paste", 
+    invoke = paketti_paste 
+}
+
+renoise.tool():add_keybinding { 
+    name = "Pattern Editor:" .. APP_NAME .. ":Paketti Mix-Paste", 
+    invoke = paketti_mix_paste 
+}
+
+--------------------------------------------------------------------------------
+-- MIDI Mappings (Paketti pattern)
+--------------------------------------------------------------------------------
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Copy Selection to Text",
+    invoke = function(message)
+        if message:is_trigger() then
+            copy_selection_to_text(true)
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Quick Copy (No Dialog)",
+    invoke = function(message)
+        if message:is_trigger() then
+            quick_copy_selection()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Paste Text Data",
+    invoke = function(message)
+        if message:is_trigger() then
+            show_paste_dialog()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Show Main Dialog",
+    invoke = function(message)
+        if message:is_trigger() then
+            show_main_dialog()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Mix-Paste (Empty Cells Only)",
+    invoke = function(message)
+        if message:is_trigger() then
+            mix_paste_from_buffer()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Paketti Copy",
+    invoke = function(message)
+        if message:is_trigger() then
+            paketti_copy()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Paketti Cut",
+    invoke = function(message)
+        if message:is_trigger() then
+            paketti_cut()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Paketti Paste",
+    invoke = function(message)
+        if message:is_trigger() then
+            paketti_paste()
+        end
+    end
+}
+
+renoise.tool():add_midi_mapping {
+    name = APP_NAME .. ":Paketti Mix-Paste",
+    invoke = function(message)
+        if message:is_trigger() then
+            paketti_mix_paste()
+        end
+    end
+}
+
+--------------------------------------------------------------------------------
+-- Startup
+--------------------------------------------------------------------------------
+log(APP_NAME .. " v" .. APP_VERSION .. " loaded successfully")
+log("Features: Full note columns, multi-track, mix-paste, file I/O, MIDI mappings")
+log("Paketti Clipboard: Copy/Cut/Paste using persistent clipboard file at: " .. PAKETTI_CLIPBOARD_FILE)

--- a/manifest.xml
+++ b/manifest.xml
@@ -2,10 +2,10 @@
 <RenoiseScriptingTool doc_version="0">
   <Name>Copy Paste Tool</Name>
   <Id>com.psychedel.CopyPaste</Id>
-  <Version>0.2</Version>
+  <Version>0.5</Version>
   <ApiVersion>6</ApiVersion>
   <Author>Psychedel</Author>
-  <Description>Tool for easy text copy/paste of pattern data between Renoise and external applications, with save/load functionality for .regpat files</Description>
+  <Description>Enhanced pattern copy/paste tool for AI collaboration. Copy pattern data as human-readable text, share with AI assistants (ChatGPT, Claude, etc.), and paste modified data back. Features: Full note columns (Note, Instrument, Volume, Panning, Delay, Sample Effects), Mix-Paste mode (only fill empty cells - Impulse Tracker Alt-M style), Paketti Clipboard (file-based Cut/Copy/Paste), multiple tracks, effect columns, file I/O (.regpat), MIDI mappings, and undo integration.</Description>
   <Category>Pattern Editor</Category>
   <Homepage>https://github.com/psychedel/Renoise-CopyPaste</Homepage>
 </RenoiseScriptingTool>


### PR DESCRIPTION
  - Introduces Paketti Clipboard, a file-based Cut/Copy/Paste system that works across Renoise sessions    
  - Adds Mix-Paste mode (Impulse Tracker Alt-M style) — paste only into empty cells                        
  - Expands note column support to include Panning, Delay, and Sample Effects                              
  - Adds MIDI mappings for all operations and Quick Copy for dialog-free workflow                          
                                                                                                           
  What's New                                                                                               
                                                                                                           
  Paketti Clipboard System                                                                                 
  A persistent, file-based clipboard designed for fast tracker-style workflows:                            
  - Paketti Copy — Copies selection to a persistent clipboard file (no dialog)                             
  - Paketti Cut — Copies to clipboard, then clears the selection                                           
  - Paketti Paste — Pastes from clipboard to current selection                                             
  - Paketti Mix-Paste — Pastes into empty cells only, preserving existing notes                            
                                                                                                           
  The clipboard survives Renoise restarts. Assign keybindings for classic tracker muscle memory.           
                                                                                                           
  Mix-Paste Mode (Impulse Tracker Alt-M)                                                                   
  Non-destructive pasting that only fills empty cells. Perfect for:                                        
  - Layering patterns together                                                                             
  - Adding effects to existing melodies                                                                    
  - Merging pattern clips without overwriting                                                              
                                                                                                           
  Full Note Column Support                                                                                 
  Format upgraded from V1 to V2, now capturing all sub-columns:                                            
  - Note → Instrument → Volume → Panning → Delay → Sample FX                                               
                                                                                                           
  Additional Improvements                                                                                  
  - Quick Copy — Copy without opening a dialog for faster iteration                                        
  - MIDI Mappings — Trigger all operations from hardware controllers                                       
  - Song context in headers — BPM, LPB, and pattern number now exported                                    
  - Proper Escape key handling — All dialogs close cleanly                                                 
  - Improved error handling — Bounds checking prevents crashes on edge cases                               
                                                                                                           
  Test Plan                                                                                                
                                                                                                           
  - Select pattern data → Paketti Copy → move to new location → Paketti Paste                              
  - Select pattern data → Paketti Cut → verify selection is cleared → Paketti Paste elsewhere              
  - Create pattern with gaps → Paketti Mix-Paste → verify only empty cells filled                          
  - Copy pattern with panning/delay/sample FX → paste → verify all columns preserved                       
  - Restart Renoise → Paketti Paste → verify clipboard persisted                                           
  - Assign MIDI mapping → trigger operations from controller                                               
  - Test undo (Ctrl+Z) after paste operations 

@psychedel 